### PR TITLE
feat: local portrait image + tab title rename

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,7 +11,7 @@ const inter = Inter({
 });
 
 export const metadata: Metadata = {
-  title: "Portfolio | Analista Programador & FullStack Developer",
+  title: "Portafolio | Analista Programador & FullStack Developer",
   description:
     "Arquitectura limpia, rendimiento y escalabilidad. Especialista en JavaScript, Node.js, React, .NET y PostgreSQL. Soluciones bien pensadas desde la arquitectura hasta la experiencia final.",
   keywords: [
@@ -26,7 +26,7 @@ export const metadata: Metadata = {
   ],
   authors: [{ name: "Portfolio" }],
   openGraph: {
-    title: "Portfolio | Analista Programador & FullStack Developer",
+    title: "Portafolio | Analista Programador & FullStack Developer",
     description:
       "Arquitectura limpia, rendimiento y escalabilidad. Soluciones bien pensadas.",
   },

--- a/components/about/About.tsx
+++ b/components/about/About.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { motion } from "framer-motion";
 
 const block = {
@@ -10,9 +11,6 @@ const block = {
     transition: { duration: 0.5, ease: [0.25, 0.46, 0.45, 0.94] },
   },
 };
-
-const PORTRAIT_URL =
-  "https://lh3.googleusercontent.com/aida-public/AB6AXuAgN_EpYkabbAcprPvFoHLWoya-0IkkT9FsgZdQioqUochA4Us_xSoLSPPpMXHO7-URkb9WK2LNANnkJYgzTr4YuFULkdNhPXjpaFty_tt9toRxKlehfdwBvVaq1pF2QQFSqhuDBMFRjN5H6vGKORHLWezDWNPr6uDd_zK-xOco7uhPgUNgA4_nUBFWet_oD272UireIirYjMuChx3M8Un8H90i5suraYHyiXEQRHfcjCGjXFGOURNEEby5h_7q0u6fIhp3mwnFCPCW";
 
 export function About() {
   return (
@@ -91,12 +89,14 @@ export function About() {
           transition={{ duration: 0.6, ease: [0.25, 0.46, 0.45, 0.94] }}
         >
           <div className="relative z-10 aspect-square bg-slate-800 rounded-3xl overflow-hidden border border-white/5 group">
-            <div className="absolute inset-0 bg-gradient-to-tr from-primary/20 to-transparent mix-blend-overlay" />
-            <div
-              className="w-full h-full bg-cover bg-center transition-transform duration-700 group-hover:scale-110"
-              style={{ backgroundImage: `url('${PORTRAIT_URL}')` }}
-              role="img"
-              aria-label="Retrato profesional"
+            <div className="absolute inset-0 z-10 bg-gradient-to-tr from-primary/20 to-transparent mix-blend-overlay" />
+            <Image
+              src="/portrait.webp"
+              alt="Retrato profesional"
+              fill
+              className="object-cover transition-transform duration-700 group-hover:scale-110"
+              sizes="(max-width: 1024px) 100vw, 40vw"
+              priority
             />
           </div>
           <div className="absolute -bottom-6 -right-6 w-full h-full border-2 border-primary/20 rounded-3xl -z-10 transform rotate-3" />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Cambios

### Imagen de retrato local
- Reemplaza la URL externa de Google (`lh3.googleusercontent.com`) por una imagen local `/portrait.webp`
- Usa el componente `next/image` con `fill`, `priority` y `sizes` optimizados
- **Requiere:** agregar la imagen generada como `public/portrait.webp`

### Título de pestaña
- Renombrado de "Portfolio" a **"Portafolio"** en `<title>` y OpenGraph metadata
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8045f62b-9c11-45e2-b1f3-5fe00daaa5cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8045f62b-9c11-45e2-b1f3-5fe00daaa5cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

